### PR TITLE
Several fixes after trying out

### DIFF
--- a/Interfaces/Utilities/DCommands.py
+++ b/Interfaces/Utilities/DCommands.py
@@ -1,6 +1,5 @@
 
 import os.path
-import sys
 import re
 import uuid
 import stat
@@ -10,20 +9,19 @@ import random
 from ConfigParser import SafeConfigParser, NoOptionError, NoSectionError
 
 import DIRAC
-from DIRAC  import S_OK, S_ERROR, gConfig
+from DIRAC  import S_OK, S_ERROR, gConfig, gLogger
 import DIRAC.Core.Security.ProxyInfo as ProxyInfo
 import DIRAC.FrameworkSystem.Client.ProxyGeneration as ProxyGeneration
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 from DIRAC.Core.Security import Locations, VOMS
-from DIRAC.Resources.Catalog.FileCatalogFactory import FileCatalogFactory
+from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
 from DIRAC.Core.Utilities.PrettyPrint import printTable
 
-# TODO: replace error() and critical() functions with DIRACish ones?
 def error( msg ):
-  sys.stderr.write( msg + "\n" )
+  gLogger.error( msg )
 
 def critical( msg, exitCode = -1 ):
-  error( msg )
+  gLogger.fatal( msg )
   DIRAC.exit( exitCode )
 
 #-----------------------------
@@ -598,21 +596,15 @@ def getDNFromProxy():
 # DCommands FC/LFN helpers
 # -------------------------
 
-def createCatalog( fctype = "FileCatalog" ):
-  result = FileCatalogFactory().createCatalog( fctype )
-  if not result[ 'OK' ]:
-    print result[ 'Message' ]
-    return None
-
-  catalog = result[ 'Value' ]
-  return catalog
+def createCatalog():
+  return FileCatalog()
 
 class DCatalog( object ):
   """
   DIRAC File Catalog helper
   """
-  def __init__( self, fctype = "FileCatalog" ):
-    self.catalog = createCatalog( fctype )
+  def __init__( self ):
+    self.catalog = createCatalog()
 
   def isDir( self, path ):
     result = self.catalog.isDirectory( path )

--- a/Interfaces/scripts/dchgrp.py
+++ b/Interfaces/scripts/dchgrp.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+########################################################################
+# $HeadURL$
+########################################################################
+
+"""
+Change file owner's group
+"""
+
+from DIRAC.Core.Base import Script
+from DIRAC import S_OK
+
+class Params:
+  def __init__ ( self ):
+    self.recursive = False
+
+  def setRecursive( self, opt):
+    self.recursive = True
+    return S_OK()
+
+  def getRecursive( self ):
+    return self.recursive
+
+params = Params( )
+
+Script.setUsageMessage( '\n'.join( [ __doc__.split( '\n' )[1],
+                                     'Usage:',
+                                     '  %s [options] group Path...' % Script.scriptName,
+                                     'Arguments:',
+                                     '  group:    new group name',
+                                     '  Path:     path to file',
+                                     '', 'Examples:',
+                                     '  $ dchown atsareg ././some_lfn_file',
+                                     '  $ dchown -R pgay ./',
+                                     ] )
+                        )
+Script.registerSwitch( "R", "recursive", "recursive", params.setRecursive )
+
+Script.parseCommandLine( ignoreErrors = True )
+args = Script.getPositionalArgs()
+
+import DIRAC
+from DIRAC import gLogger
+from COMDIRAC.Interfaces import DSession
+from COMDIRAC.Interfaces import DCatalog
+from COMDIRAC.Interfaces import pathFromArgument
+
+session = DSession( )
+catalog = DCatalog( )
+
+if len( args ) < 2:
+  print "Error: not enough arguments provided\n%s:" % Script.scriptName
+  Script.showHelp( )
+  DIRAC.exit( -1 )
+
+group = args[ 0 ]
+
+lfns = [ ]
+for path in args[ 1: ]:
+  lfns.append( pathFromArgument( session, path ))
+
+from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
+
+fc = FileCatalog()
+
+for lfn in lfns:
+  try:
+    pathDict = { lfn: group }
+    result = fc.changePathGroup( pathDict, params.recursive )
+    if not result['OK']:
+      gLogger.error( "Error:", result['Message'] )
+      break
+    if lfn in result['Value']['Failed']:
+      gLogger.error( "Error:", result['Value']['Failed'][lfn] )
+  except Exception, x:
+    print "Exception:", str(x)  

--- a/Interfaces/scripts/dchmod.py
+++ b/Interfaces/scripts/dchmod.py
@@ -4,8 +4,6 @@
 change file mode bits
 """
 
-import os
-
 import DIRAC
 
 from COMDIRAC.Interfaces import critical

--- a/Interfaces/scripts/dchmod.py
+++ b/Interfaces/scripts/dchmod.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
+########################################################################
+# $HeadURL$
+########################################################################
 
 """
-change file mode bits
+Change file mode bits
 """
 
 from DIRAC.Core.Base import Script

--- a/Interfaces/scripts/dchown.py
+++ b/Interfaces/scripts/dchown.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+########################################################################
+# $HeadURL$
+########################################################################
+
+"""
+Change file owner
+"""
+
+from DIRAC.Core.Base import Script
+from DIRAC import S_OK
+
+class Params:
+  def __init__ ( self ):
+    self.recursive = False
+
+  def setRecursive( self, opt):
+    self.recursive = True
+    return S_OK()
+
+  def getRecursive( self ):
+    return self.recursive
+
+params = Params( )
+
+Script.setUsageMessage( '\n'.join( [ __doc__.split( '\n' )[1],
+                                     'Usage:',
+                                     '  %s [options] owner Path...' % Script.scriptName,
+                                     'Arguments:',
+                                     '  owner:    new owner name',
+                                     '  Path:     path to file',
+                                     '', 'Examples:',
+                                     '  $ dchown atsareg ././some_lfn_file',
+                                     '  $ dchown -R pgay ./',
+                                     ] )
+                        )
+Script.registerSwitch( "R", "recursive", "recursive", params.setRecursive )
+
+Script.parseCommandLine( ignoreErrors = True )
+args = Script.getPositionalArgs()
+
+import DIRAC
+from DIRAC import gLogger
+from COMDIRAC.Interfaces import DSession
+from COMDIRAC.Interfaces import DCatalog
+from COMDIRAC.Interfaces import pathFromArgument
+
+session = DSession( )
+catalog = DCatalog( )
+
+if len( args ) < 2:
+  print "Error: not enough arguments provided\n%s:" % Script.scriptName
+  Script.showHelp( )
+  DIRAC.exit( -1 )
+
+owner = args[ 0 ]
+
+lfns = [ ]
+for path in args[ 1: ]:
+  lfns.append( pathFromArgument( session, path ))
+
+from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
+
+fc = FileCatalog()
+
+for lfn in lfns:
+  try:
+    pathDict = { lfn: owner }
+    result = fc.changePathOwner( pathDict, params.recursive )
+    if not result['OK']:
+      gLogger.error( "Error:", result['Message'] )
+      break
+    if lfn in result['Value']['Failed']:
+      gLogger.error( "Error:", result['Value']['Failed'][lfn] )
+  except Exception, x:
+    print "Exception:", str(x)  

--- a/Interfaces/scripts/dconfig.py
+++ b/Interfaces/scripts/dconfig.py
@@ -4,7 +4,6 @@
 configure DCommands
 """
 
-import sys
 import types
 
 import DIRAC
@@ -45,7 +44,7 @@ Script.setUsageMessage( '\n'.join( [ __doc__.split( '\n' )[1],
                                      ' section.option=value:     set option value', ] )
                         )
 Script.registerSwitch( "m", "minimal", "verify and fill minimal configuration", params.setMinimal )
-Script.registerSwitch( "", "guess", "", params.setGuessProfiles )
+Script.registerSwitch( "g", "guess", "", params.setGuessProfiles )
 
 Script.disableCS()
 

--- a/Interfaces/scripts/dlogging.py
+++ b/Interfaces/scripts/dlogging.py
@@ -4,16 +4,9 @@
 
 import DIRAC
 from DIRAC.Core.Base import Script
-from DIRAC.Core.DISET.RPCClient import RPCClient
-
-import os, shutil, datetime
-
-from COMDIRAC.Interfaces import DSession
-from COMDIRAC.Interfaces.Utilities.DCommands import ArrayFormatter
 
 class Params:
-  def __init__ ( self, session ):
-    self.__session = session
+  def __init__ ( self ):
     self.fmt = "pretty"
 
   def setFmt( self, arg = None ):
@@ -22,18 +15,20 @@ class Params:
   def getFmt( self ):
     return self.fmt
 
-session = DSession()
-params = Params( session )
+params = Params()
 
 Script.setUsageMessage( '\n'.join( [ __doc__.split( '\n' )[1],
                                      'Usage:',
                                      '  %s [option|cfgfile] ... JobID ...' % Script.scriptName,
                                      'Arguments:',
                                      '  JobID:    DIRAC Job ID' ] ) )
-Script.registerSwitch( "", "Fmt=", "display format (pretty, csv, json)", params.setFmt )
+Script.registerSwitch( "f:", "Fmt=", "display format (pretty, csv, json)", params.setFmt )
 
 Script.parseCommandLine( ignoreErrors = True )
 args = Script.getPositionalArgs()
+
+from DIRAC.Core.DISET.RPCClient import RPCClient
+from COMDIRAC.Interfaces.Utilities.DCommands import ArrayFormatter
 
 exitCode = 0
 

--- a/Interfaces/scripts/dls.py
+++ b/Interfaces/scripts/dls.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
           self.entries.sort( key=lambda x: x[ 6 ] ) 
       
       # Determine the field widths
-      wList = [ 0 for x in range( 7 ) ]
+      wList = [0] * 7
       for d in self.entries:
         for i in range( 7 ):
           if len( str( d[ i ] )) > wList[ i ]:


### PR DESCRIPTION
Several fixes to reduce the use of FileCatalogCLI, use FileCatalog() object. This is not yet fully accomplished but should be done. Multiple commands had wrong order in the import preventing the DIRAC configuration resolution logic form behaving properly. 
