### PR TITLE
pathFromArgument always return a normalized path

### DIFF
--- a/Interfaces/Utilities/DCommands.py
+++ b/Interfaces/Utilities/DCommands.py
@@ -642,10 +642,10 @@ class DCatalog( object ):
     return self.catalog.getFileUserMetadata( path )
 
 def pathFromArgument( session, arg ):
-  if not os.path.isabs( arg ):
-    arg = os.path.normpath( os.path.join( session.getCwd(), arg ) )
-
-  return arg
+  path = os.path.normpath( arg )
+  if not os.path.isabs( path ):
+    path = os.path.normpath( os.path.join( session.getCwd(), path ) )
+  return path
 
 def pathFromArguments( session, args ):
   ret = [ ]

--- a/Interfaces/scripts/dcd.py
+++ b/Interfaces/scripts/dcd.py
@@ -9,6 +9,7 @@ import os
 from COMDIRAC.Interfaces import critical
 from COMDIRAC.Interfaces import DSession
 from COMDIRAC.Interfaces import DCatalog
+from COMDIRAC.Interfaces import pathFromArgument
 
 from DIRAC.Core.Base import Script
 
@@ -34,9 +35,7 @@ if len( args ) > 1:
   DIRAC.exit( -1 )
 
 if len( args ):
-  arg = args[ 0 ]
-  if not os.path.isabs( arg ):
-    arg = os.path.normpath( os.path.join( session.getCwd( ), arg ))
+  arg = pathFromArgument( session, args[ 0 ] )
 else:
   arg = session.homeDir( )
 

--- a/Interfaces/scripts/dls.py
+++ b/Interfaces/scripts/dls.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
   
       self.entries[ -1 ] += tuple( replicas )
   
-    def human_readable_size(self,num,suffix='B'):
+    def humanReadableSize(self,num,suffix='B'):
       """ Translate file size in bytes to human readable
 
           Powers of 2 are used (1Mi = 2^20 = 1048576 bytes).
@@ -138,7 +138,7 @@ if __name__ == "__main__":
       for d in self.entries:
         for i in range( 7 ):
           if humanread and i == 4:
-            humanread_len = len( str( self.human_readable_size( d[ 4 ] )) )
+            humanread_len = len( str( self.humanReadableSize( d[ 4 ] )) )
             if humanread_len > wList[ 4 ]:
               wList[ 4 ] = humanread_len
           else:
@@ -148,7 +148,7 @@ if __name__ == "__main__":
       for e in self.entries:
         size = e[ 4 ]
         if humanread:
-          size = self.human_readable_size(e[ 4 ])
+          size = self.humanReadableSize(e[ 4 ])
 
         print str( e[ 0 ] ),
         print str( e[ 1 ] ).rjust( wList[ 1 ] ),


### PR DESCRIPTION
```
* Interfaces/scripts/dls.py (human_readable_size): Fix cameCase (humanReadableSize).
* Interfaces/Utilities/DCommands.py (pathFromArgument): always return a normalized path.
* Interfaces/scripts/dcd.py: dcd uses pathFromArgument.
```
