### PR TITLE
Avoid code duplication dls w/ fcCLI

### DIFF
--- a/Interfaces/scripts/dls.py
+++ b/Interfaces/scripts/dls.py
@@ -23,6 +23,7 @@ if __name__ == "__main__":
                                        '  $ dls /'] ) )
   Script.registerSwitch( "l", "long", "detailed listing")
   Script.registerSwitch( "L", "list-replicas", "detailed listing with replicas")
+  Script.registerSwitch( "f", "full-path", "Show full path")
   Script.registerSwitch( "t", "time", "time based order")
   Script.registerSwitch( "r", "reverse", "reverse sort order")
   Script.registerSwitch( "n", "numericid", "numeric UID and GID")
@@ -31,8 +32,8 @@ if __name__ == "__main__":
 
   Script.parseCommandLine( ignoreErrors = True )
   opts = [ ntup[0] for ntup in Script.getUnprocessedSwitches() ]
-  short_opts = ['l','L','t','r','n','S','H']
-  long_opts = ['long','list-replicas','time','reverse',
+  short_opts = ['l','L','f','t','r','n','S','H']
+  long_opts = ['long','list-replicas','full-path','time','reverse',
                'numericid','size','human-readable']
   optsDict = dict( zip( long_opts, short_opts ) )
 

--- a/Interfaces/scripts/dls.py
+++ b/Interfaces/scripts/dls.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
   Script.parseCommandLine( ignoreErrors = True )
   args = Script.getPositionalArgs()
 
-  from DIRAC.DataManagementSystem.Client.DirectoryListing import DirectoryListing
+  from DIRAC.DataManagementSystem.Utilities.CLIUtilities import DirectoryListing
   from DIRAC.DataManagementSystem.Client.FileCatalogClientCLI import FileCatalogClientCLI
 
   class ReplicaDirectoryListing( DirectoryListing ):
@@ -101,67 +101,6 @@ if __name__ == "__main__":
       self.addFile( name, fileDict, replicas, numericid )
   
       self.entries[ -1 ] += tuple( replicas )
-  
-    def humanReadableSize(self,num,suffix='B'):
-      """ Translate file size in bytes to human readable
-
-          Powers of 2 are used (1Mi = 2^20 = 1048576 bytes).
-      """
-      num = int(num)
-      for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
-        if abs(num) < 1024.0:
-          return "%3.1f%s%s" % (num, unit, suffix)
-        num /= 1024.0
-      return "%.1f%s%s" % (num, 'Yi', suffix)
-
-    def printListing( self,reverse,timeorder,sizeorder,humanread):
-      """
-      """
-      if timeorder:
-        if reverse:
-          self.entries.sort( key=lambda x: x[ 5 ] ) 
-        else:  
-          self.entries.sort( key=lambda x: x[ 5 ],reverse=True ) 
-      elif sizeorder:  
-        if reverse:
-          self.entries.sort(key=lambda x: x[4])
-        else:  
-          self.entries.sort(key=lambda x: x[4],reverse=True)
-      else:  
-        if reverse:
-          self.entries.sort( key=lambda x: x[ 6 ],reverse=True ) 
-        else:  
-          self.entries.sort( key=lambda x: x[ 6 ] ) 
-      
-      # Determine the field widths
-      wList = [0] * 7
-      for d in self.entries:
-        for i in range( 7 ):
-          if humanread and i == 4:
-            humanread_len = len( str( self.humanReadableSize( d[ 4 ] )) )
-            if humanread_len > wList[ 4 ]:
-              wList[ 4 ] = humanread_len
-          else:
-            if len( str( d[ i ] )) > wList[ i ]:
-              wList[ i ] = len( str( d[ i ] ))
-      
-      for e in self.entries:
-        size = e[ 4 ]
-        if humanread:
-          size = self.humanReadableSize(e[ 4 ])
-
-        print str( e[ 0 ] ),
-        print str( e[ 1 ] ).rjust( wList[ 1 ] ),
-        print str( e[ 2 ] ).ljust( wList[ 2 ] ),
-        print str( e[ 3 ] ).ljust( wList[ 3 ] ),
-        print str(  size  ).rjust( wList[ 4 ] ),
-        print str( e[ 5 ] ).rjust( wList[ 5 ] ),
-        print str( e[ 6 ] )
-  
-        # print replicas if present
-        if len( e ) > 7:
-          for r in e[ 7: ]:
-            print "  ", r
   
   class ReplicaFileCatalogClientCLI( FileCatalogClientCLI ):
     def getReplicas( self, path ):

--- a/Interfaces/scripts/dls.py
+++ b/Interfaces/scripts/dls.py
@@ -4,90 +4,41 @@
 list FileCatalog file or directory
 """
 
-import getopt
-
 from COMDIRAC.Interfaces import DSession
 from COMDIRAC.Interfaces import createCatalog
-from COMDIRAC.Interfaces import pathFromArguments
+from DIRAC.Core.Utilities.List import uniqueElements
 
 if __name__ == "__main__":
-  import sys
   from DIRAC.Core.Base import Script
 
-  class Params:
-    def __init__ ( self ):
-      self.long = False
-      self.replicas = False
-      self.time = False
-      self.reverse = False
-      self.numericid = False
-      self.size = False
-      self.human = False
-
-    def setLong( self, arg = None ):
-      self.long = True
-
-    def getLong( self ):
-      return self.long
-
-    def setReplicas( self, arg = None ):
-      self.replicas = True
-
-    def getReplicas( self ):
-      return self.replicas
-
-    def setTime( self, arg = None ):
-      self.time = True
-
-    def setReverse( self, arg = None ):
-      self.reverse = True
-
-    def setNumericID( self, arg = None ):
-      self.numericid = True
-
-    def setSize( self, arg = None ):
-      self.size = True
-
-    def setHuman( self, arg = None ):
-      self.human = True
-
-    def getTime( self ):
-      return self.time
-
-    def getReverse( self ):
-      return self.reverse
-
-    def getNumericID( self ):
-      return self.numericid
-
-    def getSize( self ):
-      return self.size
-
-    def getHuman( self ):
-      return self.human
-
-  params = Params( )
 
   Script.setUsageMessage( '\n'.join( [ __doc__.split( '\n' )[1],
                                        'Usage:',
-                                       '  %s [options] [path]' % Script.scriptName,
+                                       '  %s [options] [path] ... [path]' % Script.scriptName,
                                        'Arguments:',
                                        ' path:     file/directory path',
                                        '', 'Examples:',
                                        '  $ dls',
                                        '  $ dls ..',
-                                       '  $ dls /',
-                                       ] )
-                          )
-  Script.registerSwitch( "l", "long", "detailled listing", params.setLong )
-  Script.registerSwitch( "L", "list-replicas", "detailled listing with replicas", params.setReplicas )
-  Script.registerSwitch( "t", "time", "time based order", params.setTime )
-  Script.registerSwitch( "r", "reverse", "reverse sort order", params.setReverse )
-  Script.registerSwitch( "n", "numericid", "numeric UID and GID", params.setNumericID )
-  Script.registerSwitch( "S", "size", "size based order", params.setSize )
-  Script.registerSwitch( "H", "human-readable","size human readable", params.setHuman )
+                                       '  $ dls /'] ) )
+  Script.registerSwitch( "l", "long", "detailed listing")
+  Script.registerSwitch( "L", "list-replicas", "detailed listing with replicas")
+  Script.registerSwitch( "t", "time", "time based order")
+  Script.registerSwitch( "r", "reverse", "reverse sort order")
+  Script.registerSwitch( "n", "numericid", "numeric UID and GID")
+  Script.registerSwitch( "S", "size", "size based order")
+  Script.registerSwitch( "H", "human-readable","size human readable")
 
   Script.parseCommandLine( ignoreErrors = True )
+  opts = [ ntup[0] for ntup in Script.getUnprocessedSwitches() ]
+  short_opts = ['l','L','t','r','n','S','H']
+  long_opts = ['long','list-replicas','time','reverse',
+               'numericid','size','human-readable']
+  optsDict = dict( zip( long_opts, short_opts ) )
+
+  for lopt,sopt in optsDict.items():
+    opts = [ xopt.replace( lopt, sopt ) for xopt in opts ]
+
   args = Script.getPositionalArgs()
 
   from DIRAC.DataManagementSystem.Client.FileCatalogClientCLI import FileCatalogClientCLI
@@ -96,52 +47,14 @@ if __name__ == "__main__":
 
   Script.enableCS( )
 
-  fccli = None
+  fccli = FileCatalogClientCLI( createCatalog( ) )
+  # Allow duplicate options: do_ls method take care on how
+  # to order files checking which opt. from ['t','S'] comes last.
+  options = ''
+  arguments = ' '.join( uniqueElements ( args ) )
+  cmdArgs = arguments
+  if opts:
+    options = '-' + ''.join( opts )
+    cmdArgs = options + ' ' + arguments
 
-  if params.getReplicas( ):
-    fccli = FileCatalogClientCLI( createCatalog( ) )
-    params.setLong( None )
-  else:
-    fccli = FileCatalogClientCLI( createCatalog( ) )
-
-  optstr = ""
-  if params.long:       optstr += "l"
-  if params.time:       optstr += "t"
-  if params.repliacs:   optstr += "L"
-  if params.reverse:    optstr += "r"
-  if params.numericid:  optstr += "n"
-  if params.size:       optstr += "S"
-  if params.human:      optstr += "H"
-
-  if optstr: optstr = "-" + optstr + " "
-  # Need to check which was given the last 't' or 'S'
-  # This would introduce some duplication of code :-(
-  if params.long and params.time and params.size:
-    short_opts = 'lLtrnSH'
-    long_opts = ['long','timeorder','reverse','numericid','sizeorder','human-readable']
-    try:
-      optlist, arguments = getopt.getopt( sys.argv[1:],short_opts,long_opts )
-      options = [ opt for (opt, arg) in optlist ]
-      options = [ w.replace('--sizeorder','-S') for w in options ]
-      options = [ w.replace('--timeorder','-t') for w in options ]
-      options.reverse()
-      # The last ['-S','-t'] provided is the one we use: reverse order
-      # means that the last provided has the smallest index.
-      # Indeed, setTime/setSize dont has impact: the important thing is
-      # to add '-S'/'-t' at the end, then do_ls takes care of the rest.
-      if options.index('-S') < options.index('-t'):
-        params.setTime( False )
-        optstr = optstr + '-S '
-      else:
-        params.setSize( False )
-        optstr = optstr + '-t '
-
-    except getopt.GetoptError, e:
-      print str(e)
-      print fccli.do_ls.__doc__
-      exit(1)
-
-  for p in pathFromArguments( session, args ):
-    print "%s:" % p
-    fccli.do_ls( optstr + p )
-
+  fccli.do_ls( cmdArgs )

--- a/Interfaces/scripts/dls.py
+++ b/Interfaces/scripts/dls.py
@@ -3,10 +3,11 @@
 """
 list FileCatalog file or directory
 """
-
+import sys
 from COMDIRAC.Interfaces import DSession
 from COMDIRAC.Interfaces import createCatalog
 from DIRAC.Core.Utilities.List import uniqueElements
+from DIRAC  import gLogger
 
 if __name__ == "__main__":
   from DIRAC.Core.Base import Script
@@ -32,6 +33,19 @@ if __name__ == "__main__":
 
   Script.parseCommandLine( ignoreErrors = True )
   opts = [ ntup[0] for ntup in Script.getUnprocessedSwitches() ]
+  ###########################################################################
+  from DIRAC import version as diracVersion
+  if diracVersion < 'v6r14':
+    # dirac version < v6r14 ignore long options consisting of
+    # two words (e.g. --foo-bar)
+    missing_opts = ['list-replicas','full-path','human-readable']
+    for parsed_opt in missing_opts:
+      opt = '--' + parsed_opt
+      if opt in sys.argv[1:] and parsed_opt not in opts:
+        gLogger.warn("Found valid option '%s' not parsed by Script" %opt)
+        opts.append( parsed_opt )
+  ###########################################################################
+    
   short_opts = ['l','L','f','t','r','n','S','H']
   long_opts = ['long','list-replicas','full-path','time','reverse',
                'numericid','size','human-readable']


### PR DESCRIPTION
The goal of present PR consist on:

1) Avoid duplication of code between dls.py and FileCatalogClientCLI.py. 
   Move class DirectoryListing into new file CLIUtilities. In fact, after second commit, 
   dls doesn't depend on CLIUtilities.py.

2) Pass all arguments to fcCLI:do_ls with just one function call.
