### PR TITLE
cache full config mergedCFG instead of remoteCFG

### DIFF
--- a/Interfaces/Utilities/DConfigCache.py
+++ b/Interfaces/Utilities/DConfigCache.py
@@ -59,9 +59,6 @@ class ConfigCache:
       cacheStamp = os.stat( self.configCacheName ).st_mtime
       # print time.time() - cacheStamp, self.configCacheLifetime, time.time() - cacheStamp <= self.configCacheLifetime
       if time.time() - cacheStamp <= self.configCacheLifetime:
-        gConfigurationData.remoteCFG = cPickle.load( open( self.configCacheName, "r" ) )
-        # This merges the so obtained remote configuration with the local stuff
-        gConfigurationData.sync()
         Script.disableCS()
         self.newConfig = False
         # print 'use cached config'
@@ -72,4 +69,6 @@ class ConfigCache:
 
       with open( self.configCacheName, "w" ) as f:
         os.chmod( self.configCacheName, stat.S_IRUSR | stat.S_IWUSR )
-        cPickle.dump( gConfigurationData.remoteCFG, f )
+        cPickle.dump( gConfigurationData.mergedCFG, f )
+    else:
+      gConfigurationData.mergedCFG = cPickle.load( open( self.configCacheName, "r" ) )


### PR DESCRIPTION
Caching the full mergedCFG instead of only the remoteCFG speeds up loading since costly `sync()`calls are not to be done again.

If local configuration changes during the cache lifetime (user should be aware of this event), one can force reload of remote config and thus trigger merge with new local config with the command:
`dinit --fromProxy`
