### PR TITLE
[2.0] Fix dls - printout in case of -L options

### DIFF
--- a/src/COMDIRAC/Interfaces/scripts/dls.py
+++ b/src/COMDIRAC/Interfaces/scripts/dls.py
@@ -163,26 +163,15 @@ def main():
                 size = e[4]
                 if humanread:
                     size = self.humanReadableSize(e[4])
-
                 print(
                     str(e[0]),
-                )
-                print(
                     str(e[1]).rjust(wList[1]),
-                )
-                print(
                     str(e[2]).ljust(wList[2]),
-                )
-                print(
                     str(e[3]).ljust(wList[3]),
-                )
-                print(
                     str(size).rjust(wList[4]),
-                )
-                print(
                     str(e[5]).rjust(wList[5]),
+                    str(e[6]),
                 )
-                print(str(e[6]))
 
                 # print replicas if present
                 if len(e) > 7:


### PR DESCRIPTION
Different components of this printout were printed each on a new line.